### PR TITLE
Clean up package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "insomnia-url": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/insomnia-url/-/insomnia-url-0.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-mastercard-auth",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "insomnia-plugin-mastercard-auth",
   "version": "1.1.0",
-  "author": "floatinglacier <floatinglacier@gmail.com>",
+  "contributors": [
+    "floatinglacier <floatinglacier@gmail.com>",
+    "Kenny Chow",
+    "Piyush Hirpara",
+    "Brian Thompson"
+  ],
   "description": "Mastercard API Auth for Insomnia",
   "license": "Apache-2.0",
   "repository": "https://github.com/Mastercard/insomnia-plugin-mastercard-auth",
@@ -16,7 +21,6 @@
   "dependencies": {
     "insomnia-url": "^0.1.2",
     "mastercard-oauth1-signer": ">=1.1.4",
-    "node-forge": ">=0.9.1",
-    "fs": ""
+    "node-forge": ">=0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-mastercard-auth",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "contributors": [
     "floatinglacier <floatinglacier@gmail.com>",
     "Kenny Chow",

--- a/src/mastercard-auth.js
+++ b/src/mastercard-auth.js
@@ -11,15 +11,13 @@ module.exports = function (context) {
     context.request.setParameter(entry.name, entry.value.replace(/,/g, "%25252C"));    
   });
 
-  
   const qs = buildQueryStringFromParams(context.request.getParameters());
   const fullUrl = joinUrlAndQueryString(context.request.getUrl(), qs);
   const url = smartEncodeUrl(fullUrl, true);
-
   const mastercard = context.request.getEnvironmentVariable('mastercard');
+
   if (mastercard) {
     try {
-
       const p12Content = fs.readFileSync(mastercard.keystoreP12Path, 'binary');
       const p12Asn1 = forge.asn1.fromDer(p12Content, false);
       const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, false, mastercard.keystorePassword);
@@ -28,11 +26,9 @@ module.exports = function (context) {
                            bagType: forge.pki.oids.pkcs8ShroudedKeyBag
                             }).friendlyName[0];
       const signingKey = forge.pki.privateKeyToPem(keyObj.key);
-
       const authHeader = oauth.getAuthorizationHeader(URL.parse(url), context.request.getMethod(), context.request.getBodyText(), mastercard.consumerKey, signingKey);
+
       context.request.setHeader('Authorization', authHeader);
-
-
     } catch (err) {
       alert(err.message);
     }


### PR DESCRIPTION
The main change here is to remove `fs` from the package.json.  It's a core dependency of Node.js and doesn't need to be defined in package.json since that is for non-core dependencies. It also adds some confusion to the package-lock.json with a non-existent package [`fs@0.0.1-security`](https://www.npmjs.com/package/fs).

* Change author to maintainers to package.json and add maintainers
* Remove empty lines where needed
* Remove core Node.js dependency from package.json; doesn't need to be defined there