### PR TITLE
Comma encoding fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-mastercard-auth",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "insomnia-plugin-mastercard-auth",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "contributors": [
     "floatinglacier <floatinglacier@gmail.com>",
     "Kenny Chow",
     "Piyush Hirpara",
-    "Brian Thompson"
+    "Brian Thompson",
+    "Ross Phelan"
   ],
   "description": "An Insomnia plugin for handling authentication when integrating with Mastercard APIs.",
   "license": "Apache-2.0",

--- a/src/mastercard-auth.js
+++ b/src/mastercard-auth.js
@@ -6,14 +6,14 @@ const URL = require('url');
 
 module.exports = function (context) {
   
-  //handling for comma values because the gateway expects it to be percent encoded
-  context.request.getParameters().forEach( (entry) => {
-    context.request.setParameter(entry.name, entry.value.replace(/,/g, "%25252C"));    
-  });
-
   const qs = buildQueryStringFromParams(context.request.getParameters());
   const fullUrl = joinUrlAndQueryString(context.request.getUrl(), qs);
-  const url = smartEncodeUrl(fullUrl, true);
+  const commaDecodedUrl = smartEncodeUrl(fullUrl, true);
+
+  //OAuth requires all , as %2C
+  //In the above functions (at insomnia-url/src/queryString.js:72) all %2C gets decoded
+  url = commaDecodedUrl.replace(/,/g, "%2C");
+
   const mastercard = context.request.getEnvironmentVariable('mastercard');
 
   if (mastercard) {


### PR DESCRIPTION
OAuth signing requires that all commas be encoded as %2C. The Insomnia URL library decodes all commas. Before this fix commas were triple encoded (, -> %2C -> %252C -> %25252C) to try to avoid the commas getting fully decoded. This fix removes that and recodes the commas after the Insomnia URL library does it's thing

