### PR TITLE
Disabling request signing for non-MC hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "Kenny Chow",
     "Piyush Hirpara",
     "Brian Thompson",
-    "Ross Phelan"
+    "Ross Phelan",
+    "Danny Gallagher"
   ],
   "description": "An Insomnia plugin for handling authentication when integrating with Mastercard APIs.",
   "license": "Apache-2.0",

--- a/src/mastercard-auth.js
+++ b/src/mastercard-auth.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const URL = require('url');
 
 module.exports = function (context) {
-  
+
   const qs = buildQueryStringFromParams(context.request.getParameters());
   const fullUrl = joinUrlAndQueryString(context.request.getUrl(), qs);
   const commaDecodedUrl = smartEncodeUrl(fullUrl, true);
@@ -16,7 +16,7 @@ module.exports = function (context) {
 
   const mastercard = context.request.getEnvironmentVariable('mastercard');
 
-  if (mastercard) {
+  if (mastercard && commaDecodedUrl.includes('api.mastercard.com')) {
     try {
       const p12Content = fs.readFileSync(mastercard.keystoreP12Path, 'binary');
       const p12Asn1 = forge.asn1.fromDer(p12Content, false);


### PR DESCRIPTION
Addressing the following issue: https://github.com/Mastercard/insomnia-plugin-mastercard-auth/issues/12

Only hosts with 'api.mastercard.com' in their URL are now signed.