### PR TITLE
added ethocaweb.com to the appliesTo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Linux/MacOS
     "keystoreP12Path": "/path/to/sandbox-signing-key.p12",
     "keystorePassword": "keystorepassword",
     "appliesTo": [
-      "mastercard.com"
+      "mastercard.com",
+      "api.ethocaweb.com"
     ]
   }
 }
@@ -99,7 +100,8 @@ Windows
     "keystoreP12Path": "C:\\path\\to\\keystore.p12",
     "keystorePassword": "keystorepassword",
     "appliesTo": [
-      "mastercard.com"
+      "mastercard.com",
+      "api.ethocaweb.com"
     ]
   }
 }

--- a/src/mastercard-auth.js
+++ b/src/mastercard-auth.js
@@ -25,7 +25,7 @@ module.exports = function (context) {
     
     // The plugin is only active for certain URIs. By default, it intercepts API calls 
     // sent to "mastercard.com" URIs.
-    const appliesTo = mastercard.appliesTo ? mastercard.appliesTo : [ "mastercard.com" ]
+    const appliesTo = mastercard.appliesTo ? mastercard.appliesTo : [ "mastercard.com", "ethocaweb.com" ]
     appliesTo.forEach((it) => {
       if(commaDecodedUrl.includes(it)){
         signRequest = true

--- a/src/mastercard-auth.js
+++ b/src/mastercard-auth.js
@@ -25,7 +25,7 @@ module.exports = function (context) {
     
     // The plugin is only active for certain URIs. By default, it intercepts API calls 
     // sent to "mastercard.com" URIs.
-    const appliesTo = mastercard.appliesTo ? mastercard.appliesTo : [ "mastercard.com", "ethocaweb.com" ]
+    const appliesTo = mastercard.appliesTo ? mastercard.appliesTo : [ "mastercard.com", "api.ethocaweb.com" ]
     appliesTo.forEach((it) => {
       if(commaDecodedUrl.includes(it)){
         signRequest = true

--- a/workspace/mastercard-apis-insomnia-workspace.json
+++ b/workspace/mastercard-apis-insomnia-workspace.json
@@ -66,7 +66,8 @@
                     "keystoreP12Path": "/path/to/production-signing-key.p12",
                     "keystorePassword": "keystorepassword",
                     "appliesTo": [
-                      "mastercard.com"
+                      "mastercard.com",
+                      "api.ethocaweb.com"
                     ]
                 }
             },
@@ -102,7 +103,8 @@
                     "keystoreP12Path": "/path/to/sandbox-signing-key.p12",
                     "keystorePassword": "keystorepassword",
                     "appliesTo": [
-                      "mastercard.com"
+                      "mastercard.com",
+                      "api.ethocaweb.com"  
                     ]
                 }
             },


### PR DESCRIPTION
We have added *.api.ethocaweb.com to the mastercard akamai to re-route to api.mastercard.com. 
This is to allow clients to connect to an ethoca branded URL (as some issuers dont want to be associated with mastercard (ie capital one)), backed by the mastercard infrastructure.